### PR TITLE
Fix pip error: metadata-generation-failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author="Luciano Pereira",
     author_email="luciano.pereira.valenzuela@gmail.com",
     license="Apache 2.0",
+    packages=["ECC2025"],
     install_requires=["numpy", "scipy", "qiskit", "qiskit_ibm_runtime", 
                         "qiskit_aer", "pylatexenc", "matplotlib"],
 )


### PR DESCRIPTION
Since there are multiple top-level directories (ECC2025, img), pip does not know which to build and stops. This PR fixes that problem by specifying to build ECC2025.