### PR TITLE
Fix import path for random_circuit

### DIFF
--- a/ECC2025/testing.py
+++ b/ECC2025/testing.py
@@ -10,7 +10,7 @@ from scipy.linalg import expm
 from qiskit_ibm_runtime.fake_provider import FakeBurlingtonV2 as FakeDevice
 from qiskit_aer import AerSimulator
 from qiskit import transpile
-from qiskit.circuit import random_circuit
+from qiskit.circuit.random import random_circuit
 from qiskit_algorithms import VQE
 from qiskit_algorithms.optimizers import COBYLA
 


### PR DESCRIPTION
The current path is no longer `qiskit.circuit.random_circuit` but `qiskit.circuit.random.random_circuit`. This PR fixes that and solves issue #16.